### PR TITLE
Test tooling v1 (SolidityStruct, computeHash functions)

### DIFF
--- a/packages/apps/test/countingGame.spec.ts
+++ b/packages/apps/test/countingGame.spec.ts
@@ -29,8 +29,8 @@ contract("CountingApp", (accounts: string[]) => {
   describe("reducer", () => {
     it("should work for increment", async () => {
       const baseState = {
-        player1: Utils.zeroAddress,
-        player2: Utils.zeroAddress,
+        player1: Utils.ZERO_ADDRESS,
+        player2: Utils.ZERO_ADDRESS,
         count: 0,
         turnNum: 0
       };
@@ -50,8 +50,8 @@ contract("CountingApp", (accounts: string[]) => {
 
     it("should work for decrement", async () => {
       const baseState = {
-        player1: Utils.zeroAddress,
-        player2: Utils.zeroAddress,
+        player1: Utils.ZERO_ADDRESS,
+        player2: Utils.ZERO_ADDRESS,
         count: 5,
         turnNum: 1
       };
@@ -71,8 +71,8 @@ contract("CountingApp", (accounts: string[]) => {
 
     it("should fail for unknown action", async () => {
       const baseState = {
-        player1: Utils.zeroAddress,
-        player2: Utils.zeroAddress,
+        player1: Utils.ZERO_ADDRESS,
+        player2: Utils.ZERO_ADDRESS,
         count: 0,
         turnNum: 0
       };

--- a/packages/apps/test/nim.spec.ts
+++ b/packages/apps/test/nim.spec.ts
@@ -24,7 +24,7 @@ contract("Nim", (accounts: string[]) => {
   describe("reducer", () => {
     it("can take from a pile", async () => {
       const preState = {
-        players: [Utils.zeroAddress, Utils.zeroAddress],
+        players: [Utils.ZERO_ADDRESS, Utils.ZERO_ADDRESS],
         turnNum: 0,
         pileHeights: [6, 5, 12]
       };
@@ -49,7 +49,7 @@ contract("Nim", (accounts: string[]) => {
 
     it("can take to produce an empty pile", async () => {
       const preState = {
-        players: [Utils.zeroAddress, Utils.zeroAddress],
+        players: [Utils.ZERO_ADDRESS, Utils.ZERO_ADDRESS],
         turnNum: 0,
         pileHeights: [6, 5, 12]
       };
@@ -74,7 +74,7 @@ contract("Nim", (accounts: string[]) => {
 
     it("should fail for taking too much", async () => {
       const preState = {
-        players: [Utils.zeroAddress, Utils.zeroAddress],
+        players: [Utils.ZERO_ADDRESS, Utils.ZERO_ADDRESS],
         turnNum: 0,
         pileHeights: [6, 5, 12]
       };
@@ -91,7 +91,7 @@ contract("Nim", (accounts: string[]) => {
   describe("isFinal", () => {
     it("empty state is final", async () => {
       const preState = {
-        players: [Utils.zeroAddress, Utils.zeroAddress],
+        players: [Utils.ZERO_ADDRESS, Utils.ZERO_ADDRESS],
         turnNum: 49,
         pileHeights: [0, 0, 0]
       };
@@ -101,7 +101,7 @@ contract("Nim", (accounts: string[]) => {
 
     it("nonempty state is not final", async () => {
       const preState = {
-        players: [Utils.zeroAddress, Utils.zeroAddress],
+        players: [Utils.ZERO_ADDRESS, Utils.ZERO_ADDRESS],
         turnNum: 49,
         pileHeights: [0, 1, 0]
       };

--- a/packages/contracts/test/helpers/cfhelpers.ts
+++ b/packages/contracts/test/helpers/cfhelpers.ts
@@ -62,7 +62,7 @@ export function getCFHelper(
             ["bytes32"],
             [contract.address]
           ),
-          registry: Utils.zeroAddress
+          registry: Utils.ZERO_ADDRESS
         };
       } else {
         return {

--- a/packages/contracts/test/helpers/multisig.ts
+++ b/packages/contracts/test/helpers/multisig.ts
@@ -1,6 +1,6 @@
 import {
   deployContract,
-  highGasLimit,
+  HIGH_GAS_LIMIT,
   signMessageBytes
 } from "@counterfactual/test-utils";
 import * as ethers from "ethers";
@@ -126,7 +126,7 @@ export default class Multisig {
       calldata,
       operation,
       signatures,
-      highGasLimit
+      HIGH_GAS_LIMIT
     );
   }
 }

--- a/packages/contracts/test/integration/commitReveal.spec.ts
+++ b/packages/contracts/test/integration/commitReveal.spec.ts
@@ -1,14 +1,27 @@
 import * as ethers from "ethers";
 
-import * as Utils from "@counterfactual/test-utils";
+import {
+  App,
+  computeStateHash,
+  deployContract,
+  deployContractViaRegistry,
+  getDeployedContract,
+  HIGH_GAS_LIMIT,
+  setupTestEnv,
+  signMessageBytes,
+  SolidityStructType,
+  TransferTerms,
+  UNIT_ETH,
+  ZERO_ADDRESS
+} from "@counterfactual/test-utils";
 import Multisig from "../helpers/multisig";
 
 const CommitRevealApp = artifacts.require("CommitRevealApp");
 
 const web3 = (global as any).web3;
-const { provider, unlockedAccount: masterAccount } = Utils.setupTestEnv(web3);
+const { provider, unlockedAccount: masterAccount } = setupTestEnv(web3);
 
-const [A, B] = [
+const [alice, bob] = [
   // 0xaeF082d339D227646DB914f0cA9fF02c8544F30b
   new ethers.Wallet(
     "0x3570f77380e22f8dc2274d8fd33e7830cc2d29cf76804e8c21f4f7a6cc571d27",
@@ -20,17 +33,6 @@ const [A, B] = [
     provider
   )
 ];
-
-function computeStateHash(
-  appStateHash: string,
-  nonce: number,
-  timeout: number
-) {
-  return ethers.utils.solidityKeccak256(
-    ["bytes1", "address[]", "uint256", "uint256", "bytes32"],
-    ["0x19", [A.address, B.address], nonce, timeout, appStateHash]
-  );
-}
 
 function computeCommitHash(appSalt: string, chosenNumber: number) {
   return ethers.utils.solidityKeccak256(
@@ -44,15 +46,6 @@ function computeNonceRegistryKey(multisigAddress: string, nonceSalt: string) {
     ["address", "bytes32"],
     [multisigAddress, nonceSalt]
   );
-}
-
-function encode(encoding: string, state: any) {
-  return ethers.utils.defaultAbiCoder.encode([encoding], [state]);
-}
-
-function keccak256Struct(encoding: string, struct: any) {
-  const bytes = ethers.utils.defaultAbiCoder.encode([encoding], [struct]);
-  return ethers.utils.solidityKeccak256(["bytes"], [bytes]);
 }
 
 enum AssetType {
@@ -73,7 +66,7 @@ enum Player {
   GUESSING = 1
 }
 
-describe("CommitRevealApp", async () => {
+describe("CommitReveal", async () => {
   const StateChannel = artifacts.require("StateChannel");
   const ConditionalTransfer = artifacts.require("ConditionalTransfer");
   const StaticCall = artifacts.require("StaticCall");
@@ -81,17 +74,6 @@ describe("CommitRevealApp", async () => {
   const Registry = artifacts.require("Registry");
   const Signatures = artifacts.require("Signatures");
   const Transfer = artifacts.require("Transfer");
-
-  let app;
-
-  const appEncoding =
-    "tuple(address addr, bytes4 reducer, bytes4 resolver, bytes4 turnTaker, bytes4 isStateFinal)";
-
-  const appStateEncoding =
-    "tuple(address[2] playerAddrs, uint256 stage, uint256 maximum, " +
-    "uint256 guessedNumber, bytes32 commitHash, uint256 winner)";
-
-  const termsEncoding = "tuple(uint8 assetType, uint256 limit, address token)";
 
   beforeEach(async () => {
     CommitRevealApp.link("StaticCall", StaticCall.address);
@@ -104,49 +86,43 @@ describe("CommitRevealApp", async () => {
   it("should complete a full lifecycle", async function() {
     this.timeout(4000);
 
-    const startBalanceA = await A.getBalance();
-    const startBalanceB = await B.getBalance();
+    const startBalanceA = await alice.getBalance();
+    const startBalanceB = await bob.getBalance();
+
     // 1. Deploy & fund multisig
-    const multisig = new Multisig([A.address, B.address]);
+    const multisig = new Multisig([alice.address, bob.address]);
     await multisig.deploy(masterAccount);
     await masterAccount.sendTransaction({
       to: multisig.address,
-      value: Utils.UNIT_ETH.mul(2)
+      value: UNIT_ETH.mul(2)
     });
 
-    const terms = {
+    const terms = TransferTerms.new({
       assetType: AssetType.ETH,
-      limit: Utils.UNIT_ETH.mul(2),
-      token: Utils.zeroAddress
-    };
+      limit: UNIT_ETH.mul(2),
+      token: ZERO_ADDRESS
+    });
     // 2. Deploy CommitRevealApp app
-    const appContract = await Utils.deployContract(
-      CommitRevealApp,
-      masterAccount
-    );
-    app = {
+    const appContract = await deployContract(CommitRevealApp, masterAccount);
+    const app = App.new({
       addr: appContract.address,
       reducer: appContract.interface.functions.reducer.sighash,
       resolver: appContract.interface.functions.resolver.sighash,
       turnTaker: appContract.interface.functions.getTurnTaker.sighash,
       isStateFinal: appContract.interface.functions.isStateFinal.sighash
-    };
+    });
 
     // 3. Deploy StateChannel
-    const args = [
-      multisig.address,
-      [A.address, B.address],
-      keccak256Struct(appEncoding, app),
-      keccak256Struct(termsEncoding, terms),
-      10
-    ];
-    const {
-      cfAddr,
-      contract: stateChannel
-    } = await Utils.deployContractViaRegistry(
+    const { cfAddr, contract: stateChannel } = await deployContractViaRegistry(
       StateChannel,
       masterAccount,
-      args
+      [
+        multisig.address,
+        [alice.address, bob.address],
+        app.keccak256(),
+        terms.keccak256(),
+        10
+      ]
     );
 
     // 4. Call setState(claimFinal=true) on StateChannel with a final state
@@ -156,67 +132,80 @@ describe("CommitRevealApp", async () => {
 
     const commitHash = computeCommitHash(appSalt, chosenNumber);
 
-    const finalAppState = {
-      playerAddrs: [A.address, B.address],
+    const AppState = new SolidityStructType(`
+      address[2] playerAddrs;
+      uint256 stage;
+      uint256 maximum;
+      uint256 guessedNumber;
+      bytes32 commitHash;
+      uint256 winner;
+    `);
+
+    const appState = AppState.new({
+      playerAddrs: [alice.address, bob.address],
       stage: Stage.DONE,
       maximum: 10,
       guessedNumber: 1,
       commitHash,
       winner: Player.CHOOSING
-    };
+    });
 
     const appNonce = 5;
     const timeout = 0;
-    const appStateHash = keccak256Struct(appStateEncoding, finalAppState);
-    const stateHash = computeStateHash(appStateHash, appNonce, 0);
-    const signatures = Utils.signMessageBytes(stateHash, [A, B]);
+    const appStateHash = appState.keccak256();
+    const stateHash = computeStateHash(multisig.owners, appState, appNonce, 0);
+    const signatures = signMessageBytes(stateHash, [alice, bob]);
     await stateChannel.functions.setState(
       appStateHash,
       appNonce,
       timeout,
       signatures,
-      Utils.highGasLimit
+      HIGH_GAS_LIMIT
     );
     // 5. Call setResolution() on StateChannel
     await stateChannel.functions.setResolution(
-      app,
-      encode(appStateEncoding, finalAppState),
-      encode(termsEncoding, terms)
+      app.asObject(),
+      appState.encodeBytes(),
+      terms.encodeBytes()
     );
 
     const channelNonce = 1;
-    const nonceSalt =
+    const channelNonceSalt =
       "0x3004efe76b684aef3c1b29448e84d461ff211ddba19cdf75eb5e31eebbb6999b";
 
     // 6. Call setNonce on NonceRegistry with some salt and nonce
-    const nonceRegistry: ethers.Contract = await Utils.getDeployedContract(
+    const nonceRegistry: ethers.Contract = await getDeployedContract(
       NonceRegistry,
       masterAccount
     );
     await multisig.execCall(
       nonceRegistry,
       "setNonce",
-      [nonceSalt, channelNonce],
-      [A, B]
+      [channelNonceSalt, channelNonce],
+      [alice, bob]
     );
+
     await multisig.execCall(
       nonceRegistry,
       "finalizeNonce",
-      [nonceSalt],
-      [A, B]
+      [channelNonceSalt],
+      [alice, bob]
     );
 
-    const nonceKey = computeNonceRegistryKey(multisig.address, nonceSalt);
+    const channelNonceKey = computeNonceRegistryKey(
+      multisig.address,
+      channelNonceSalt
+    );
     (await nonceRegistry.functions.isFinalized(
-      nonceKey,
+      channelNonceKey,
       channelNonce
     )).should.be.equal(true);
     // // 7. Call executeStateChannelConditionalTransfer on ConditionalTransfer from multisig
-    const conditionalTransfer: ethers.Contract = await Utils.getDeployedContract(
+    const conditionalTransfer: ethers.Contract = await getDeployedContract(
       ConditionalTransfer,
       masterAccount
     );
-    const registry: ethers.Contract = await Utils.getDeployedContract(
+    const registry: ethers.Contract = await getDeployedContract(
       Registry,
       masterAccount
     );
@@ -226,17 +215,19 @@ describe("CommitRevealApp", async () => {
       [
         registry.address,
         nonceRegistry.address,
-        nonceKey,
+        channelNonceKey,
         channelNonce,
         cfAddr,
-        terms
+        terms.asObject()
       ],
-      [A, B]
+      [alice, bob]
     );
+
     // 8. Verify balance of A and B
-    (await A.getBalance())
-      .sub(startBalanceA)
-      .should.be.bignumber.eq(Utils.UNIT_ETH.mul(2));
-    (await B.getBalance()).should.be.bignumber.eq(startBalanceB);
+    const endBalanceA = await alice.getBalance();
+    const endBalanceB = await bob.getBalance();
+
+    endBalanceA.sub(startBalanceA).should.be.bignumber.eq(UNIT_ETH.mul(2));
+    endBalanceB.should.be.bignumber.eq(startBalanceB);
   });
 });

--- a/packages/contracts/test/integration/countingGame.spec.ts
+++ b/packages/contracts/test/integration/countingGame.spec.ts
@@ -1,11 +1,25 @@
 import * as ethers from "ethers";
 
-import * as Utils from "@counterfactual/test-utils";
+import {
+  App,
+  assertRejects,
+  computeActionHash,
+  computeStateHash,
+  deployContract,
+  HIGH_GAS_LIMIT,
+  setupTestEnv,
+  signMessageBytes,
+  SolidityStruct,
+  SolidityStructType,
+  TransferTerms,
+  ZERO_ADDRESS,
+  ZERO_BYTES32
+} from "@counterfactual/test-utils";
 
 const CountingApp = artifacts.require("CountingApp");
 
 const web3 = (global as any).web3;
-const { provider, unlockedAccount } = Utils.setupTestEnv(web3);
+const { provider, unlockedAccount } = setupTestEnv(web3);
 
 const [A, B] = [
   // 0xaeF082d339D227646DB914f0cA9fF02c8544F30b
@@ -18,34 +32,9 @@ const [A, B] = [
   )
 ];
 
-const computeStateHash = (stateHash: string, nonce: number, timeout: number) =>
-  ethers.utils.solidityKeccak256(
-    ["bytes1", "address[]", "uint256", "uint256", "bytes32"],
-    ["0x19", [A.address, B.address], nonce, timeout, stateHash]
-  );
-
-const computeActionHash = (
-  turn: string,
-  prevState: string,
-  action: string,
-  setStateNonce: number,
-  disputeNonce: number
-) =>
-  ethers.utils.solidityKeccak256(
-    ["bytes1", "address", "bytes32", "bytes", "uint256", "uint256"],
-    ["0x19", turn, prevState, action, setStateNonce, disputeNonce]
-  );
-
 contract("CountingApp", (accounts: string[]) => {
-  let game: ethers.Contract;
+  let appContract: ethers.Contract;
   let stateChannel: ethers.Contract;
-
-  const exampleState = {
-    player1: A.address,
-    player2: B.address,
-    count: 0,
-    turnNum: 0
-  };
 
   enum AssetType {
     ETH,
@@ -53,67 +42,44 @@ contract("CountingApp", (accounts: string[]) => {
     ANY
   }
 
-  const encode = (encoding: string, state: any) =>
-    ethers.utils.defaultAbiCoder.encode([encoding], [state]);
-
-  const decode = (encoding: string, state: any) =>
-    ethers.utils.defaultAbiCoder.decode([encoding], state);
-
-  const latestNonce = async () => stateChannel.functions.latestNonce();
+  async function latestNonce(): Promise<number> {
+    return parseInt(await stateChannel.functions.latestNonce(), 10);
+  }
 
   // TODO: Wait for this to work:
   // ethers.utils.formatParamType(iface.functions.resolver.inputs[0])
   // github.com/ethers-io/ethers.js/blob/typescript/src.ts/utils/abi-coder.ts#L301
-  const gameEncoding =
-    "tuple(address player1, address player2, uint256 count, uint256 turnNum)";
 
-  const appEncoding =
-    "tuple(address addr, bytes4 reducer, bytes4 resolver, bytes4 turnTaker, bytes4 isStateFinal)";
-
-  const termsEncoding = "tuple(uint8 assetType, uint256 limit, address token)";
-
-  const detailsEncoding =
-    "tuple(uint8 assetType, address token, address[] to, uint256[] amount, bytes data)";
-
-  const keccak256 = (bytes: string) =>
-    ethers.utils.solidityKeccak256(["bytes"], [bytes]);
-
-  const sendUpdateToChainWithNonce = (nonce: number, appState?: string) =>
-    stateChannel.functions.setState(
-      appState || Utils.zeroBytes32,
+  const sendSignedFinalizationToChain = async (state: SolidityStruct) => {
+    const nonce = await latestNonce();
+    const stateHash = computeStateHash([A.address, B.address], state, nonce, 0);
+    return stateChannel.functions.setState(
+      state.keccak256(),
       nonce,
-      10,
-      "0x",
-      Utils.highGasLimit
-    );
-
-  const sendSignedUpdateToChainWithNonce = (nonce: number, appState?: string) =>
-    stateChannel.functions.setState(
-      appState || Utils.zeroBytes32,
-      nonce,
-      10,
-      Utils.signMessageBytes(
-        computeStateHash(appState || Utils.zeroBytes32, nonce, 10),
-        [unlockedAccount]
-      ),
-      Utils.highGasLimit
-    );
-
-  const sendSignedFinalizationToChain = async (stateHash: string) =>
-    stateChannel.functions.setState(
-      stateHash,
-      await latestNonce(),
       0,
-      Utils.signMessageBytes(
-        computeStateHash(
-          stateHash || Utils.zeroBytes32,
-          await latestNonce(),
-          0
-        ),
-        [unlockedAccount]
-      ),
-      Utils.highGasLimit
+      signMessageBytes(stateHash, [unlockedAccount]),
+      HIGH_GAS_LIMIT
     );
+  };
+
+  const Action = new SolidityStructType(`
+    uint256 actionType;
+    uint256 byHowMuch;
+  `);
+
+  const AppState = new SolidityStructType(`
+    address player1;
+    address player2;
+    uint256 count;
+    uint256 turnNum;
+  `);
+
+  const exampleState = AppState.new({
+    player1: A.address,
+    player2: B.address,
+    count: 0,
+    turnNum: 0
+  });
 
   let app;
   let terms;
@@ -125,25 +91,25 @@ contract("CountingApp", (accounts: string[]) => {
 
     CountingApp.link("StaticCall", StaticCall.address);
 
-    game = await Utils.deployContract(CountingApp, unlockedAccount);
+    appContract = await deployContract(CountingApp, unlockedAccount);
 
     StateChannel.link("Signatures", Signatures.address);
     StateChannel.link("StaticCall", StaticCall.address);
     StateChannel.link("Transfer", Transfer.address);
 
-    app = {
-      addr: game.address,
-      resolver: game.interface.functions.resolver.sighash,
-      reducer: game.interface.functions.reducer.sighash,
-      turnTaker: game.interface.functions.turn.sighash,
-      isStateFinal: game.interface.functions.isStateFinal.sighash
-    };
+    app = App.new({
+      addr: appContract.address,
+      resolver: appContract.interface.functions.resolver.sighash,
+      reducer: appContract.interface.functions.reducer.sighash,
+      turnTaker: appContract.interface.functions.turn.sighash,
+      isStateFinal: appContract.interface.functions.isStateFinal.sighash
+    });
 
-    terms = {
+    terms = TransferTerms.new({
       assetType: AssetType.ETH,
-      limit: Utils.UNIT_ETH.mul(2),
-      token: Utils.zeroAddress
-    };
+      limit: ethers.utils.parseEther("2"),
+      token: ZERO_ADDRESS
+    });
 
     const contract = new ethers.Contract("", StateChannel.abi, unlockedAccount);
 
@@ -151,49 +117,50 @@ contract("CountingApp", (accounts: string[]) => {
       StateChannel.binary,
       accounts[0],
       [A.address, B.address],
-      keccak256(encode(appEncoding, app)),
-      keccak256(encode(termsEncoding, terms)),
+      app.keccak256(),
+      terms.keccak256(),
       10
     );
   });
 
   it("should resolve to some balance", async () => {
-    const ret = await game.functions.resolver(exampleState, terms);
+    const ret = await appContract.functions.resolver(
+      exampleState.asObject(),
+      terms.asObject()
+    );
     ret.assetType.should.be.equal(AssetType.ETH);
-    ret.token.should.be.equalIgnoreCase(Utils.zeroAddress);
+    ret.token.should.be.equalIgnoreCase(ZERO_ADDRESS);
     ret.to[0].should.be.equalIgnoreCase(A.address);
     ret.to[1].should.be.equalIgnoreCase(B.address);
-    ret.amount[0].should.be.bignumber.eq(Utils.UNIT_ETH.mul(2));
+    ret.amount[0].should.be.bignumber.eq(ethers.utils.parseEther("2"));
     ret.amount[1].should.be.bignumber.eq(0);
   });
 
   describe("setting a resolution", async () => {
     it("should fail before state is settled", async () => {
-      const finalState = encode(gameEncoding, exampleState);
-      await Utils.assertRejects(
+      await assertRejects(
         stateChannel.functions.setResolution(
-          app,
-          finalState,
-          encode(termsEncoding, terms),
-          Utils.highGasLimit
+          app.asObject(),
+          exampleState.encodeBytes(),
+          terms.encodeBytes(),
+          HIGH_GAS_LIMIT
         )
       );
     });
     it("should succeed after state is settled", async () => {
-      const finalState = encode(gameEncoding, exampleState);
-      await sendSignedFinalizationToChain(keccak256(finalState));
+      await sendSignedFinalizationToChain(exampleState);
       await stateChannel.functions.setResolution(
-        app,
-        finalState,
-        encode(termsEncoding, terms),
-        Utils.highGasLimit
+        app.asObject(),
+        exampleState.encodeBytes(),
+        terms.encodeBytes(),
+        HIGH_GAS_LIMIT
       );
       const ret = await stateChannel.functions.getResolution();
       ret.assetType.should.be.equal(AssetType.ETH);
-      ret.token.should.be.equalIgnoreCase(Utils.zeroAddress);
+      ret.token.should.be.equalIgnoreCase(ZERO_ADDRESS);
       ret.to[0].should.be.equalIgnoreCase(A.address);
       ret.to[1].should.be.equalIgnoreCase(B.address);
-      ret.amount[0].should.be.bignumber.eq(Utils.UNIT_ETH.mul(2));
+      ret.amount[0].should.be.bignumber.eq(ethers.utils.parseEther("2"));
       ret.amount[1].should.be.bignumber.eq(0);
     });
   });
@@ -210,41 +177,45 @@ contract("CountingApp", (accounts: string[]) => {
       OFF
     }
 
-    const actionEncoding = "tuple(uint8 actionType, uint256 byHowMuch)";
-
-    const state = encode(gameEncoding, exampleState);
-
     it("should update state based on reducer", async () => {
-      const action = {
+      const action = Action.new({
         actionType: ActionTypes.INCREMENT,
         byHowMuch: 1
-      };
+      });
 
-      const h1 = computeStateHash(keccak256(state), 1, 10);
-      const h2 = computeActionHash(
+      const stateHash = computeStateHash(
+        [A.address, B.address],
+        exampleState,
+        1,
+        10
+      );
+      const actionHash = computeActionHash(
         A.address,
-        keccak256(state),
-        encode(actionEncoding, action),
+        exampleState,
+        action,
         1,
         0
       );
 
       await stateChannel.functions.createDispute(
-        app,
-        state,
+        app.asObject(),
+        exampleState.encodeBytes(),
         1,
         10,
-        encode(actionEncoding, action),
-        Utils.signMessageBytes(h1, [A, B]),
-        Utils.signMessageBytes(h2, [A]),
+        action.encodeBytes(),
+        signMessageBytes(stateHash, [A, B]),
+        signMessageBytes(actionHash, [A]),
         false,
-        Utils.highGasLimit
+        HIGH_GAS_LIMIT
       );
 
       const onchain = await stateChannel.functions.state();
 
-      const expectedState = { ...exampleState, count: 1, turnNum: 1 };
-      const expectedStateHash = keccak256(encode(gameEncoding, expectedState));
+      const expectedState = exampleState.clone({
+        count: 1,
+        turnNum: 1
+      });
+      const expectedStateHash = expectedState.keccak256();
       const expectedFinalizeBlock = (await provider.getBlockNumber()) + 10;
 
       onchain.status.should.be.bignumber.eq(Status.DISPUTE);
@@ -257,36 +228,30 @@ contract("CountingApp", (accounts: string[]) => {
     });
 
     it("should update and finalize state based on reducer", async () => {
-      const action = {
+      const action = Action.new({
         actionType: ActionTypes.INCREMENT,
         byHowMuch: 2.0
-      };
+      });
 
-      const h1 = computeStateHash(keccak256(state), 1, 10);
-      const h2 = computeActionHash(
-        A.address,
-        keccak256(state),
-        encode(actionEncoding, action),
-        1,
-        0
-      );
+      const h1 = computeStateHash([A.address, B.address], exampleState, 1, 10);
+      const h2 = computeActionHash(A.address, exampleState, action, 1, 0);
 
       await stateChannel.functions.createDispute(
-        app,
-        state,
+        app.asObject(),
+        exampleState.encodeBytes(),
         1,
         10,
-        encode(actionEncoding, action),
-        Utils.signMessageBytes(h1, [A, B]),
-        Utils.signMessageBytes(h2, [A]),
+        action.encodeBytes(),
+        signMessageBytes(h1, [A, B]),
+        signMessageBytes(h2, [A]),
         true,
-        Utils.highGasLimit
+        HIGH_GAS_LIMIT
       );
 
       const channelState = await stateChannel.functions.state();
 
-      const expectedState = { ...exampleState, count: 2, turnNum: 1 };
-      const expectedStateHash = keccak256(encode(gameEncoding, expectedState));
+      const expectedState = exampleState.clone({ count: 2, turnNum: 1 });
+      const expectedStateHash = expectedState.keccak256();
       const expectedFinalizeBlock = await provider.getBlockNumber();
 
       channelState.status.should.be.bignumber.eq(Status.OFF);
@@ -299,31 +264,25 @@ contract("CountingApp", (accounts: string[]) => {
     });
 
     it("should fail when trying to finalize a non-final state", async () => {
-      const action = {
+      const action = Action.new({
         actionType: ActionTypes.INCREMENT,
         byHowMuch: 1.0
-      };
+      });
 
-      const h1 = computeStateHash(keccak256(state), 1, 10);
-      const h2 = computeActionHash(
-        A.address,
-        keccak256(state),
-        encode(actionEncoding, action),
-        1,
-        0
-      );
+      const h1 = computeStateHash([A.address, B.address], exampleState, 1, 10);
+      const h2 = computeActionHash(A.address, exampleState, action, 1, 0);
 
-      await Utils.assertRejects(
+      await assertRejects(
         stateChannel.functions.createDispute(
-          app,
-          state,
+          app.asObject(),
+          exampleState.encodeBytes(),
           1,
           10,
-          encode(actionEncoding, action),
-          Utils.signMessageBytes(h1, [A, B]),
-          Utils.signMessageBytes(h2, [A]),
+          action.encodeBytes(),
+          signMessageBytes(h1, [A, B]),
+          signMessageBytes(h2, [A]),
           true,
-          Utils.highGasLimit
+          HIGH_GAS_LIMIT
         )
       );
     });

--- a/packages/contracts/test/integration/twoPartyPayments.spec.ts
+++ b/packages/contracts/test/integration/twoPartyPayments.spec.ts
@@ -68,23 +68,23 @@ contract("PaymentApp", (accounts: string[]) => {
 
   const sendUpdateToChainWithNonce = (nonce: number, appState?: string) =>
     stateChannel.functions.setState(
-      appState || Utils.zeroBytes32,
+      appState || Utils.ZERO_BYTES32,
       nonce,
       10,
       "0x",
-      Utils.highGasLimit
+      Utils.HIGH_GAS_LIMIT
     );
 
   const sendSignedUpdateToChainWithNonce = (nonce: number, appState?: string) =>
     stateChannel.functions.setState(
-      appState || Utils.zeroBytes32,
+      appState || Utils.ZERO_BYTES32,
       nonce,
       10,
       Utils.signMessageBytes(
-        getUpdateHash(appState || Utils.zeroBytes32, nonce, 10),
+        getUpdateHash(appState || Utils.ZERO_BYTES32, nonce, 10),
         [unlockedAccount]
       ),
-      Utils.highGasLimit
+      Utils.HIGH_GAS_LIMIT
     );
 
   const sendSignedFinalizationToChain = async (stateHash: string) =>
@@ -93,10 +93,10 @@ contract("PaymentApp", (accounts: string[]) => {
       await latestNonce(),
       0,
       Utils.signMessageBytes(
-        getUpdateHash(stateHash || Utils.zeroBytes32, await latestNonce(), 0),
+        getUpdateHash(stateHash || Utils.ZERO_BYTES32, await latestNonce(), 0),
         [unlockedAccount]
       ),
-      Utils.highGasLimit
+      Utils.HIGH_GAS_LIMIT
     );
 
   let app;
@@ -124,7 +124,7 @@ contract("PaymentApp", (accounts: string[]) => {
     terms = {
       assetType: AssetType.ETH,
       limit: Utils.UNIT_ETH.mul(2),
-      token: Utils.zeroAddress
+      token: Utils.ZERO_ADDRESS
     };
 
     const contract = new ethers.Contract("", StateChannel.abi, unlockedAccount);
@@ -142,7 +142,7 @@ contract("PaymentApp", (accounts: string[]) => {
   it("should resolve to payments", async () => {
     const ret = await pc.functions.resolver(exampleState, terms);
     ret.assetType.should.be.equal(AssetType.ETH);
-    ret.token.should.be.equalIgnoreCase(Utils.zeroAddress);
+    ret.token.should.be.equalIgnoreCase(Utils.ZERO_ADDRESS);
     ret.to[0].should.be.equalIgnoreCase(A.address);
     ret.to[1].should.be.equalIgnoreCase(B.address);
     ret.amount[0].should.be.bignumber.eq(Utils.UNIT_ETH);
@@ -157,7 +157,7 @@ contract("PaymentApp", (accounts: string[]) => {
           app,
           finalState,
           encode(termsEncoding, terms),
-          Utils.highGasLimit
+          Utils.HIGH_GAS_LIMIT
         )
       );
     });
@@ -168,11 +168,11 @@ contract("PaymentApp", (accounts: string[]) => {
         app,
         finalState,
         encode(termsEncoding, terms),
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
       const ret = await stateChannel.functions.getResolution();
       ret.assetType.should.be.equal(AssetType.ETH);
-      ret.token.should.be.equalIgnoreCase(Utils.zeroAddress);
+      ret.token.should.be.equalIgnoreCase(Utils.ZERO_ADDRESS);
       ret.to[0].should.be.equalIgnoreCase(A.address);
       ret.to[1].should.be.equalIgnoreCase(B.address);
       ret.amount[0].should.be.bignumber.eq(Utils.UNIT_ETH);

--- a/packages/contracts/test/unit/conditional.spec.ts
+++ b/packages/contracts/test/unit/conditional.spec.ts
@@ -29,13 +29,13 @@ contract("Conditional", (accounts: string[]) => {
         [expectedValue]
       ),
       onlyCheckForSuccess,
-      parameters: Utils.zeroBytes32,
+      parameters: Utils.ZERO_BYTES32,
       selector: example.interface.functions.isSatisfiedNoParam.sighash,
       to: example.address
     });
 
     it("returns true if function did not fail", async () => {
-      const condition = makeCondition(Utils.zeroBytes32, true);
+      const condition = makeCondition(Utils.ZERO_BYTES32, true);
       const ret = await conditionContract.functions.isSatisfied(condition);
       ret.should.be.equal(true);
     });
@@ -50,7 +50,7 @@ contract("Conditional", (accounts: string[]) => {
     });
 
     it("returns false if function returns unexpected result", async () => {
-      const condition = makeCondition(Utils.zeroBytes32, false);
+      const condition = makeCondition(Utils.ZERO_BYTES32, false);
       const ret = await conditionContract.functions.isSatisfied(condition);
       ret.should.be.equal(false);
     });
@@ -79,13 +79,13 @@ contract("Conditional", (accounts: string[]) => {
     );
 
     it("returns true if function did not fail", async () => {
-      const condition = makeCondition(Utils.zeroBytes32, trueParam, true);
+      const condition = makeCondition(Utils.ZERO_BYTES32, trueParam, true);
       const ret = await conditionContract.functions.isSatisfied(condition);
       ret.should.be.equal(true);
     });
 
     it("returns true if function did not fail but returned false", async () => {
-      const condition = makeCondition(Utils.zeroBytes32, falseParam, true);
+      const condition = makeCondition(Utils.ZERO_BYTES32, falseParam, true);
       const ret = await conditionContract.functions.isSatisfied(condition);
       ret.should.be.equal(true);
     });
@@ -101,7 +101,7 @@ contract("Conditional", (accounts: string[]) => {
     });
 
     it("returns false if function returns unexpected result", async () => {
-      const condition = makeCondition(Utils.zeroBytes32, falseParam, false);
+      const condition = makeCondition(Utils.ZERO_BYTES32, falseParam, false);
       const ret = await conditionContract.functions.isSatisfied(condition);
       ret.should.be.equal(false);
     });

--- a/packages/contracts/test/unit/conditionalTransfer.spec.ts
+++ b/packages/contracts/test/unit/conditionalTransfer.spec.ts
@@ -27,7 +27,7 @@ contract("ConditionalTransfer", (accounts: string[]) => {
         [expectedValue]
       ),
       onlyCheckForSuccess,
-      parameters: Utils.zeroBytes32,
+      parameters: Utils.ZERO_BYTES32,
       selector: condition.interface.functions.isSatisfiedNoParam.sighash,
       to: condition.address
     });
@@ -64,13 +64,13 @@ contract("ConditionalTransfer", (accounts: string[]) => {
       const randomTarget = Utils.randomETHAddress();
       const tx = ct.interface.functions.executeSimpleConditionalTransfer.encode(
         [
-          makeCondition(Utils.zeroBytes32, true),
+          makeCondition(Utils.ZERO_BYTES32, true),
           {
             amount: [Utils.UNIT_ETH],
             assetType: 0,
             to: [randomTarget],
-            token: Utils.zeroAddress,
-            data: Utils.zeroAddress
+            token: Utils.ZERO_ADDRESS,
+            data: Utils.ZERO_ADDRESS
           }
         ]
       );
@@ -78,7 +78,7 @@ contract("ConditionalTransfer", (accounts: string[]) => {
       await delegateProxy.functions.delegate(
         ct.address,
         tx,
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
 
       const balTarget = await provider.getBalance(randomTarget);
@@ -97,14 +97,14 @@ contract("ConditionalTransfer", (accounts: string[]) => {
             amount: [Utils.UNIT_ETH],
             assetType: 0,
             to: [randomTarget],
-            token: Utils.zeroAddress,
-            data: Utils.zeroAddress
+            token: Utils.ZERO_ADDRESS,
+            data: Utils.ZERO_ADDRESS
           }
         ]
       );
 
       await Utils.assertRejects(
-        delegateProxy.functions.delegate(ct.address, tx, Utils.highGasLimit)
+        delegateProxy.functions.delegate(ct.address, tx, Utils.HIGH_GAS_LIMIT)
       );
 
       const balTarget = await provider.getBalance(randomTarget);

--- a/packages/contracts/test/unit/nonceRegistry.spec.ts
+++ b/packages/contracts/test/unit/nonceRegistry.spec.ts
@@ -18,8 +18,12 @@ contract("NonceRegistry", accounts => {
   });
 
   it("can set nonces", async () => {
-    await registry.functions.setNonce(Utils.zeroBytes32, 1, Utils.highGasLimit);
-    const ret = await registry.functions.table(computeKey(Utils.zeroBytes32));
+    await registry.functions.setNonce(
+      Utils.ZERO_BYTES32,
+      1,
+      Utils.HIGH_GAS_LIMIT
+    );
+    const ret = await registry.functions.table(computeKey(Utils.ZERO_BYTES32));
     ret.nonce.should.be.bignumber.eq(1);
     ret.finalizesAt.should.be.bignumber.eq(
       (await provider.getBlockNumber()) + 10
@@ -28,20 +32,20 @@ contract("NonceRegistry", accounts => {
 
   it("fails if nonce increment is not positive", async () => {
     await Utils.assertRejects(
-      registry.functions.setNonce(Utils.zeroBytes32, 0, Utils.highGasLimit)
+      registry.functions.setNonce(Utils.ZERO_BYTES32, 0, Utils.HIGH_GAS_LIMIT)
     );
   });
 
   it("can finalize nonces", async () => {
     await registry.functions.finalizeNonce(
-      Utils.zeroBytes32,
-      Utils.highGasLimit
+      Utils.ZERO_BYTES32,
+      Utils.HIGH_GAS_LIMIT
     );
-    const ret = await registry.functions.table(computeKey(Utils.zeroBytes32));
+    const ret = await registry.functions.table(computeKey(Utils.ZERO_BYTES32));
     ret.nonce.should.be.bignumber.eq(0);
     ret.finalizesAt.should.be.bignumber.eq(await provider.getBlockNumber());
     const isFinal = await registry.functions.isFinalized(
-      computeKey(Utils.zeroBytes32),
+      computeKey(Utils.ZERO_BYTES32),
       0
     );
     isFinal.should.be.equal(true);

--- a/packages/contracts/test/unit/registry.spec.ts
+++ b/packages/contracts/test/unit/registry.spec.ts
@@ -26,8 +26,8 @@ contract("Registry", accounts => {
 
   it("computes counterfactual addresses of bytes deployments", async () => {
     assert.equal(
-      cfaddress(Utils.zeroBytes32, 1),
-      await registry.cfaddress(Utils.zeroBytes32, 1)
+      cfaddress(Utils.ZERO_BYTES32, 1),
+      await registry.cfaddress(Utils.ZERO_BYTES32, 1)
     );
   });
 

--- a/packages/contracts/test/unit/stateChannel.spec.ts
+++ b/packages/contracts/test/unit/stateChannel.spec.ts
@@ -61,23 +61,23 @@ contract("StateChannel", (accounts: string[]) => {
   before(async () => {
     sendUpdateToChainWithNonce = (nonce: number, appState?: string) =>
       stateChannel.functions.setState(
-        appState || Utils.zeroBytes32,
+        appState || Utils.ZERO_BYTES32,
         nonce,
         TIMEOUT,
         "0x",
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
 
     sendSignedUpdateToChainWithNonce = (nonce: number, appState?: string) =>
       stateChannel.functions.setState(
-        appState || Utils.zeroBytes32,
+        appState || Utils.ZERO_BYTES32,
         nonce,
         TIMEOUT,
         Utils.signMessageBytes(
-          computeHash(appState || Utils.zeroBytes32, nonce, TIMEOUT),
+          computeHash(appState || Utils.ZERO_BYTES32, nonce, TIMEOUT),
           [unlockedAccount]
         ),
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
 
     sendSignedFinalizationToChain = async () =>
@@ -89,7 +89,7 @@ contract("StateChannel", (accounts: string[]) => {
           computeHash(await latestState(), await latestNonce(), 0),
           [unlockedAccount]
         ),
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
   });
 
@@ -99,8 +99,8 @@ contract("StateChannel", (accounts: string[]) => {
       StateChannel.binary,
       accounts[0],
       [A.address, B.address],
-      Utils.zeroBytes32,
-      Utils.zeroBytes32,
+      Utils.ZERO_BYTES32,
+      Utils.ZERO_BYTES32,
       10
     );
   });
@@ -197,8 +197,8 @@ contract("StateChannel", (accounts: string[]) => {
         await latestState(),
         await latestNonce(),
         0,
-        Utils.zeroBytes32,
-        Utils.highGasLimit
+        Utils.ZERO_BYTES32,
+        Utils.HIGH_GAS_LIMIT
       );
       true.should.be.equal(await stateChannel.functions.isClosed());
     });

--- a/packages/contracts/test/unit/transfer.spec.ts
+++ b/packages/contracts/test/unit/transfer.spec.ts
@@ -43,14 +43,14 @@ contract("Transfer", (accounts: string[]) => {
         amount: [Utils.UNIT_ETH],
         assetType: AssetType.ETH,
         to: [randomTarget],
-        token: Utils.zeroAddress,
-        data: Utils.zeroAddress
+        token: Utils.ZERO_ADDRESS,
+        data: Utils.ZERO_ADDRESS
       };
 
       await delegateProxy.functions.delegate(
         transfer.address,
         transfer.interface.functions.transfer.encode([details]),
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
 
       const balTarget = await provider.getBalance(randomTarget);
@@ -67,14 +67,14 @@ contract("Transfer", (accounts: string[]) => {
         amount: randomTargets.map(_ => Utils.UNIT_ETH.div(10)),
         assetType: AssetType.ETH,
         to: randomTargets,
-        token: Utils.zeroAddress,
-        data: Utils.zeroAddress
+        token: Utils.ZERO_ADDRESS,
+        data: Utils.ZERO_ADDRESS
       };
 
       await delegateProxy.functions.delegate(
         transfer.address,
         transfer.interface.functions.transfer.encode([details]),
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
 
       for (let i = 0; i < 10; i++) {
@@ -97,13 +97,13 @@ contract("Transfer", (accounts: string[]) => {
         assetType: AssetType.ERC20,
         to: [randomTarget],
         token: dolphinCoin.address,
-        data: Utils.zeroAddress
+        data: Utils.ZERO_ADDRESS
       };
 
       await delegateProxy.functions.delegate(
         transfer.address,
         transfer.interface.functions.transfer.encode([details]),
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
 
       const balTarget = await dolphinCoin.functions.balanceOf(randomTarget);
@@ -121,13 +121,13 @@ contract("Transfer", (accounts: string[]) => {
         assetType: AssetType.ERC20,
         to: randomTargets,
         token: dolphinCoin.address,
-        data: Utils.zeroAddress
+        data: Utils.ZERO_ADDRESS
       };
 
       await delegateProxy.functions.delegate(
         transfer.address,
         transfer.interface.functions.transfer.encode([details]),
-        Utils.highGasLimit
+        Utils.HIGH_GAS_LIMIT
       );
 
       for (let i = 0; i < 10; i++) {

--- a/packages/test-utils/src/contract.ts
+++ b/packages/test-utils/src/contract.ts
@@ -1,3 +1,0 @@
-import * as ethers from "ethers";
-
-export default class Contract extends ethers.Contract {}

--- a/packages/test-utils/src/contract.ts
+++ b/packages/test-utils/src/contract.ts
@@ -1,0 +1,3 @@
+import * as ethers from "ethers";
+
+export default class Contract extends ethers.Contract {}

--- a/packages/test-utils/src/solidityStruct.ts
+++ b/packages/test-utils/src/solidityStruct.ts
@@ -1,8 +1,35 @@
 import * as ethers from "ethers";
 
+/**
+ * Convenience class to define a Solidity struct type to create instances of Solidity structs.
+ * See SolidityStruct class for instance methods.
+ * @example
+ *  const AppState = new SolidityStructType(`
+ *    uint256 someNumber;
+ *    address[] someAddresses;
+ *  `);
+ *  const appState = AppState.new({
+ *    someNumber: 3,
+ *    someAddresses: ["0xbb..", "0xaa.."]
+ *  });
+ *
+ */
 export class SolidityStructType {
+  /**
+   * Struct field definitions. Format: "[type] [name]" e.g. "uint256 someNumber"
+   */
   public readonly definitions: string[] = [];
 
+  /**
+   * Create a new Solidity struct type from definition.
+   * @param solidityDefinition The Solidity definition of the struct fields. `uint256` should be substituted for Enum types.
+   * @example
+   *   new SolidityStructType(`
+   *     uint256 someEnum;
+   *     address[] someAddresses;
+   *   `);
+   * @throws Error if Solidity definition in a bad format.
+   */
   constructor(solidityDefinition: string) {
     const lines = solidityDefinition.split(";");
     for (const line of lines) {
@@ -20,11 +47,19 @@ export class SolidityStructType {
     }
   }
 
+  /**
+   * Create a new SolidityStruct instance of this type.
+   * Ensure the values are the correct types, as they are not type checked.
+   * @param values The values to assign to the struct fields.
+   */
   public new(values: { [name: string]: any }): SolidityStruct {
     return new SolidityStruct(this, values);
   }
 }
 
+/**
+ * Solidity struct convenience class for use with Counterfactual framework.
+ */
 export class SolidityStruct {
   constructor(
     private structType: SolidityStructType,
@@ -35,11 +70,19 @@ export class SolidityStruct {
     return `tuple(${this.structType.definitions.join(", ")})`;
   }
 
+  /**
+   * Compute the keccak256 hash of the ABI encoded representation of this struct.
+   * @returns string 32-byte keccak256 hash
+   */
   public keccak256(): string {
     const encoded = this.encodeBytes();
     return ethers.utils.solidityKeccak256(["bytes"], [encoded]);
   }
 
+  /**
+   * ABI encode this struct.
+   * @returns string bytestring of the ABI encoding
+   */
   public encodeBytes(): string {
     return ethers.utils.defaultAbiCoder.encode(
       [this._encoding],
@@ -47,6 +90,9 @@ export class SolidityStruct {
     );
   }
 
+  /**
+   * The struct as a Javascript object for use in a contract call.
+   */
   public asObject(): { [k: string]: any } {
     const values: { [k: string]: any } = {};
     Object.keys(this.values).forEach(name => {
@@ -59,6 +105,11 @@ export class SolidityStruct {
     return values;
   }
 
+  /**
+   * Clone this struct and assign new values to the fields.
+   * @param newValues New values to assign
+   * @returns SolidityStruct New struct of same Solidity struct type with new values
+   */
   public clone(newValues: { [k: string]: any }): SolidityStruct {
     const values = this.asObject();
     return this.structType.new({

--- a/packages/test-utils/src/solidityStruct.ts
+++ b/packages/test-utils/src/solidityStruct.ts
@@ -1,0 +1,69 @@
+import * as ethers from "ethers";
+
+export class SolidityStructType {
+  public readonly definitions: string[] = [];
+
+  constructor(solidityDefinition: string) {
+    const lines = solidityDefinition.split(";");
+    for (const line of lines) {
+      const definition = line.trim();
+      if (definition.length === 0) {
+        continue;
+      }
+      const parts = definition.split(" ");
+      if (parts.length !== 2) {
+        throw new Error(
+          `Invalid struct field. Expected '[type] [name]', got '${definition}'`
+        );
+      }
+      this.definitions.push(definition);
+    }
+  }
+
+  public new(values: { [name: string]: any }): SolidityStruct {
+    return new SolidityStruct(this, values);
+  }
+}
+
+export class SolidityStruct {
+  constructor(
+    private structType: SolidityStructType,
+    private values: { [name: string]: any }
+  ) {}
+
+  private get _encoding(): string {
+    return `tuple(${this.structType.definitions.join(", ")})`;
+  }
+
+  public keccak256(): string {
+    const encoded = this.encodeBytes();
+    return ethers.utils.solidityKeccak256(["bytes"], [encoded]);
+  }
+
+  public encodeBytes(): string {
+    return ethers.utils.defaultAbiCoder.encode(
+      [this._encoding],
+      [this.asObject()]
+    );
+  }
+
+  public asObject(): { [k: string]: any } {
+    const values: { [k: string]: any } = {};
+    Object.keys(this.values).forEach(name => {
+      let value = this.values[name];
+      if (value instanceof ethers.types.BigNumber) {
+        value = value.toHexString();
+      }
+      values[name] = value;
+    });
+    return values;
+  }
+
+  public clone(newValues: { [k: string]: any }): SolidityStruct {
+    const values = this.asObject();
+    return this.structType.new({
+      ...values,
+      ...newValues
+    });
+  }
+}

--- a/packages/test-utils/src/stateChannel.ts
+++ b/packages/test-utils/src/stateChannel.ts
@@ -1,6 +1,14 @@
 import * as ethers from "ethers";
 import { SolidityStruct, SolidityStructType } from "./solidityStruct";
 
+/**
+ * Compute the raw state hash for use in the StateChannel contract.
+ * @param signingKeys Signing keys of the StateChannel
+ * @param appState App state
+ * @param appStateNonce App state nonce
+ * @param timeout Time until finalization.
+ * @returns string 32-byte keccak256 hash
+ */
 export function computeStateHash(
   signingKeys: string[],
   appState: SolidityStruct,
@@ -13,6 +21,15 @@ export function computeStateHash(
   );
 }
 
+/**
+ * Compute the raw action hash for use in the StateChannel contract.
+ * @param turnTaker The address of the turn taker
+ * @param prevState The previous app state
+ * @param action The action
+ * @param appStateNonce The app state nonce
+ * @param disputeNonce The dispute nonce
+ * @returns string 32-byte keccak256 hash
+ */
 export function computeActionHash(
   turnTaker: string,
   prevState: SolidityStruct,
@@ -33,12 +50,18 @@ export function computeActionHash(
   );
 }
 
+/**
+ * Solidity struct type for the Transfer.Terms struct
+ */
 export const TransferTerms = new SolidityStructType(`
   uint8 assetType;
   uint256 limit;
   address token;
 `);
 
+/**
+ * Solidity struct type for the App struct
+ */
 export const App = new SolidityStructType(`
   address addr;
   bytes4 reducer;

--- a/packages/test-utils/src/stateChannel.ts
+++ b/packages/test-utils/src/stateChannel.ts
@@ -1,0 +1,48 @@
+import * as ethers from "ethers";
+import { SolidityStruct, SolidityStructType } from "./solidityStruct";
+
+export function computeStateHash(
+  signingKeys: string[],
+  appState: SolidityStruct,
+  appStateNonce: number,
+  timeout: number
+): string {
+  return ethers.utils.solidityKeccak256(
+    ["bytes1", "address[]", "uint256", "uint256", "bytes32"],
+    ["0x19", signingKeys, appStateNonce, timeout, appState.keccak256()]
+  );
+}
+
+export function computeActionHash(
+  turnTaker: string,
+  prevState: SolidityStruct,
+  action: SolidityStruct,
+  appStateNonce: number,
+  disputeNonce: number
+): string {
+  return ethers.utils.solidityKeccak256(
+    ["bytes1", "address", "bytes32", "bytes", "uint256", "uint256"],
+    [
+      "0x19",
+      turnTaker,
+      prevState.keccak256(),
+      action.encodeBytes(),
+      appStateNonce,
+      disputeNonce
+    ]
+  );
+}
+
+export const TransferTerms = new SolidityStructType(`
+  uint8 assetType;
+  uint256 limit;
+  address token;
+`);
+
+export const App = new SolidityStructType(`
+  address addr;
+  bytes4 reducer;
+  bytes4 resolver;
+  bytes4 turnTaker;
+  bytes4 isStateFinal;
+`);

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -4,6 +4,22 @@ import * as chaiBigNumber from "chai-bignumber";
 import * as chaiString from "chai-string";
 import * as ethers from "ethers";
 
+import { SolidityStruct, SolidityStructType } from "./solidityStruct";
+import {
+  App,
+  computeActionHash,
+  computeStateHash,
+  TransferTerms
+} from "./stateChannel";
+export {
+  SolidityStructType,
+  SolidityStruct,
+  computeStateHash,
+  computeActionHash,
+  TransferTerms,
+  App
+};
+
 // https://github.com/ethers-io/ethers.js/pull/225
 // @ts-ignore
 ethers.types.BigNumber.prototype.equals = function(x): boolean {
@@ -17,10 +33,9 @@ export const should = chai
   .should();
 
 export const UNIT_ETH = ethers.utils.parseEther("1");
-export const highGasLimit = { gasLimit: 6e9 };
-export const unusedAddr = "0x0000000000000000000000000000000000000001";
-export const zeroAddress = "0x0000000000000000000000000000000000000000";
-export const zeroBytes32 =
+export const HIGH_GAS_LIMIT = { gasLimit: 6e9 };
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+export const ZERO_BYTES32 =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 export const deployContract = async (
@@ -55,7 +70,7 @@ export async function deployContractViaRegistry(
     ["0x19", initcode, contractSalt]
   );
 
-  await registry.functions.deploy(initcode, contractSalt, highGasLimit);
+  await registry.functions.deploy(initcode, contractSalt, HIGH_GAS_LIMIT);
 
   const realAddr = await registry.functions.resolver(cfAddr);
 
@@ -91,7 +106,7 @@ export const setupTestEnv = (web3: any) => {
   return { provider, unlockedAccount };
 };
 
-export function signMessage(message, wallet): [number, string, string] {
+function signMessage(message, wallet): [number, string, string] {
   const signingKey = new ethers.SigningKey(wallet.privateKey);
   const sig = signingKey.signDigest(message);
   if (typeof sig.recoveryParam === "undefined") {
@@ -100,20 +115,7 @@ export function signMessage(message, wallet): [number, string, string] {
   return [sig.recoveryParam + 27, sig.r, sig.s];
 }
 
-export function signMessageVRS(message, wallets: ethers.Wallet[]) {
-  const v: number[] = [];
-  const r: string[] = [];
-  const s: string[] = [];
-  for (const wallet of wallets) {
-    const [vi, ri, si] = signMessage(message, wallet);
-    v.push(vi);
-    r.push(ri);
-    s.push(si);
-  }
-  return { v, r, s };
-}
-
-export function signMessageRaw(message: string, wallet: ethers.Wallet) {
+function signMessageRaw(message: string, wallet: ethers.Wallet) {
   const [v, r, s] = signMessage(message, wallet);
   return (
     ethers.utils.hexlify(ethers.utils.padZeros(r, 32)).substring(2) +
@@ -189,12 +191,3 @@ export const mineBlocks = async blocks => {
     await mineOneBlock();
   }
 };
-
-export async function getEthBalance(address, provider) {
-  const balance = await provider.getBalance(address);
-  return fromWei(balance);
-}
-
-export function fromWei(num) {
-  return num / 1000000000000000000;
-}


### PR DESCRIPTION
- Add new `SolidityStruct` convenience class for dealing with Solidity structs in Typescript. 
- Extract helper functions: `computeStateHash` and `computeActionHash`.
- `utils.ts`: Rename some constants and remove some unused functions. 
- Migrated commitReveal.spec.ts and countingGame.spec.ts