### PR TITLE
[POC] Hacky atomic asset swap

### DIFF
--- a/packages/apps/contracts/AssetSwap.sol
+++ b/packages/apps/contracts/AssetSwap.sol
@@ -1,0 +1,52 @@
+pragma solidity 0.4.24;
+pragma experimental "ABIEncoderV2";
+
+import "@counterfactual/contracts/contracts/lib/Transfer.sol";
+import "@counterfactual/contracts/contracts/Registry.sol";
+import "@counterfactual/contracts/contracts/StateChannel.sol";
+import "./SwapSwitch.sol";
+
+
+contract AssetSwap {
+  struct AppState {
+    address registry;
+    bytes32 parentChannelCfAddr;
+
+    address recipient;
+  }
+
+  function isParentChannelSettled(AppState state)
+    private
+    pure
+    returns (bool)
+  {
+    Registry memory registry = Registry(state.registry);
+    address parentChannelAddr = registry.resolver(state.parentChannelCfAddr);
+    StateChannel memory parentChannel = StateChannel(parentChannelAddr);
+    return parentChannel.isStateFinal(parentChannel.state);
+  }
+
+  function resolve(AppState state, Transfer.Terms terms)
+    public
+    pure
+    returns (Transfer.Details)
+  {
+    require(isParentChannelSettled(state), "Parent channel not settled");
+
+    uint256[] memory amounts = new uint256[](1);
+    amounts[0] = terms.limit;
+
+    address[] memory to = new address[](1);
+    to[0] = recipient;
+
+    bytes memory data;
+
+    return Transfer.Details(
+      terms.assetType,
+      terms.token,
+      to,
+      amounts,
+      data
+    );
+  }
+}

--- a/packages/apps/contracts/SimpleSwapSwitch.sol
+++ b/packages/apps/contracts/SimpleSwapSwitch.sol
@@ -1,0 +1,48 @@
+pragma solidity 0.4.24;
+pragma experimental "ABIEncoderV2";
+
+import "@counterfactual/contracts/contracts/lib/Transfer.sol";
+
+
+contract SimpleSwapSwitch {
+  enum ActionType {
+    SET_SWAPPED
+  }
+
+  struct Action {
+    ActionType actionType;
+  }
+
+  struct AppState {
+    bool swapped;
+  }
+
+  function isStateTerminal(AppState state)
+    public
+    pure
+    returns (bool) {
+    return state.swapped;
+  }
+
+  function turnTaker(AppState state)
+    public
+    pure
+    returns (uint256)
+  {
+    return 0;
+  }
+
+  function applyAction(AppState state, Action action)
+    public
+    view
+    returns (bytes)
+  {
+    AppState memory nextState = state;
+    if (action.actionType == ActionType.SET_SWAPPED) {
+      nextState.swapped = true;
+    } else {
+      revert("Illegal action");
+    }
+    return nextState;
+  }
+}


### PR DESCRIPTION
Proof of concept of an atomic swap of arbitrary assets, without requiring Counterfactual protocol upgrades. 

AssetSwap app contract inspects a state channel to check whether it's in a final state, and only then resolves to transfer the asset. The inspected state channel (AKA "parent channel") can house an app that contains arbitrarily complex logic for controlling and finalizing the swap. 

Any number of AssetSwaps can be tied to one parent channel.