### PR TITLE
mark some functions as pure

### DIFF
--- a/packages/apps/contracts/CommitRevealApp.sol
+++ b/packages/apps/contracts/CommitRevealApp.sol
@@ -60,7 +60,7 @@ contract CommitRevealApp {
 
   function applyAction(AppState state, Action action)
     public
-    view
+    pure
     returns (bytes)
   {
     AppState memory nextState = state;

--- a/packages/apps/contracts/CountingApp.sol
+++ b/packages/apps/contracts/CountingApp.sol
@@ -61,7 +61,7 @@ contract CountingApp {
 
   function applyAction(AppState state, Action action)
     public
-    view
+    pure
     returns (bytes)
   {
     if (action.actionType == ActionTypes.INCREMENT) {

--- a/packages/apps/contracts/Nim.sol
+++ b/packages/apps/contracts/Nim.sol
@@ -39,7 +39,7 @@ contract Nim {
 
   function applyAction(AppState state, Action action)
     public
-    view
+    pure
     returns (bytes)
   {
     require(0 <= action.pileIdx);

--- a/packages/contracts/contracts/StateChannel.sol
+++ b/packages/contracts/contracts/StateChannel.sol
@@ -458,7 +458,7 @@ contract StateChannel {
     uint256 disputeNonce
   )
     internal
-    view
+    pure
     returns (bytes32)
   {
     return keccak256(


### PR DESCRIPTION
This PR marks all `applyAction` functions in sample apps as pure (instead of view) and also marks `computeActionHash` as pure